### PR TITLE
Increase mob breeding limiter

### DIFF
--- a/plugins/ClearLag/config.yml
+++ b/plugins/ClearLag/config.yml
@@ -131,8 +131,8 @@ item-spawn-age-setter:
 # -- 'check-radius' is the radius of what clearlag will check for 'max-mobs'
 mob-breeding-limiter:
   enabled: true
-  max-mobs: 18
-  check-radius: 5
+  max-mobs: 16
+  check-radius: 2
 
 #Should clearlag purge logs under /logs when the server starts?
 # -- 'days-old' means how many days old can the log be to be deleted


### PR DESCRIPTION
The intention of this setting is to reduce lag caused by entity collision, but the current limit is way too low in terms of practical breeding. There would still be no more than 0.64 mobs standing on a single block on average after my edit, while the original limit was 0.2 mob per block. Considering the fact that cows, pigs and sheep all have a hitbox of 1x1 in area, this would still not introduce much entity collision while making it possible to breed a reasonable amount of cows/pigs for food.

Edit:
![image](https://user-images.githubusercontent.com/34199560/78972320-0f1e7880-7b40-11ea-83f7-c9477bc961bc.png)

