### PR TITLE
Remove the height limit when players fly with an elytra

### DIFF
--- a/plugins/IllegalStack/config.yml
+++ b/plugins/IllegalStack/config.yml
@@ -4,7 +4,7 @@ Exploits:
     PreventItemSwapLagExploit: true
     PreventInvalidPotions: true
     PreventRailDupe: true
-    PreventInvalidElytraFlight: true
+    PreventInvalidElytraFlight: false
     PreventNestedShulkers: true
     DisableChestsOnMobs: false
     PreventHoppersToUnloadedChunks: true


### PR DESCRIPTION
https://github.com/dniym/IllegalStack/wiki/PreventInfiniteElytraFlight
This glitch only affects versions above 1.13, and apparently the fix is that once the player reaches a certain altitude (around 300m with my testing), the player stops to deploy the elytra and therefore starts to freefall. Unless the elytra is deployed again, this may lead to potentially lethal falling damage.
![image](https://user-images.githubusercontent.com/34199560/79064229-b84ca680-7cd9-11ea-8443-73d681a7b992.png)
(Screenshot of the video demonstrating the glitch)